### PR TITLE
버그픽스

### DIFF
--- a/src/pages/kakaoAuthentication/index.tsx
+++ b/src/pages/kakaoAuthentication/index.tsx
@@ -23,7 +23,12 @@ export default function KakaoAuthenticationPage() {
         };
         signInRequest(requestBody).then((res) => {
             console.log(res);
-            const accessToken = res.data.accessToken;
+            if (res.code === 500) {
+                alert('서버 에러가 발생했습니다. 잠시 후 다시 시도해주세요.');
+                navigate('signin');
+                console.error(res.message);
+                return;
+            }
             if (res.status === 'UNAUTHORIZED' && res.code === 401) {
                 navigate(`/signup/${res.data.userUuid}`);
                 return;
@@ -31,7 +36,8 @@ export default function KakaoAuthenticationPage() {
             console.log(res.code);
             if (res.code === 200) {
                 console.log('로그인 성공.');
-                const grade = [getDivisionName(res.data.userGrade)] as string[]
+                const accessToken = res.data.accessToken;
+                const grade = [getDivisionName(res.data.userGrade)] as string[];
                 localStorage.setItem('accessToken', String(accessToken));
                 localStorage.setItem('uuid', res.data.userUuid);
                 setSearchInfoState((prev) => ({

--- a/src/pages/totalBabpool/TotalBabpoolPage.tsx
+++ b/src/pages/totalBabpool/TotalBabpoolPage.tsx
@@ -47,6 +47,7 @@ export default function TotalBabpoolPage() {
     const [filterCategory, setFilterCategory] =
         useState<FilterCategoryType>(DEFAULT_FILTER_CATEGORY);
 
+        // 프로필 리스트 요청
     const fetchProfileList = async () => {
         const { searchText, division, filterKeyword } = searchInfo;
         const requestDivision = division.map((item) => getDivisionId(item)).join(',');
@@ -68,7 +69,7 @@ export default function TotalBabpoolPage() {
     };
 
     const { data, isError, isLoading } = useQuery<ProfilesType>({
-        queryKey: ['profiles', searchInfo],
+        queryKey: ['profiles', groupName],
         queryFn: fetchProfileList,
     });
     const { navigate, authCheck } = useNavigation();
@@ -151,6 +152,7 @@ export default function TotalBabpoolPage() {
             });
         }
     }, []);
+
 
     return (
         <>


### PR DESCRIPTION
Resolves #109 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 그룹키워드 변경될 때 밥풀리스트 두번 요청되는 이슈 해결
- 카카오 로그인 예외처리 항목 추가

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 밥풀리스트 요청하는 query 키값이 searchInfo로 되어있었는데 searchInfo는 group(대학생활, 취업.. 등)이 변경될 때 상태가 변경됨에 따라 리렌더링이 발생하여 네트워크 요청이 두번일어나게 됨.
해결 - query 키를 groupName으로 변경하여 해결


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->