### PR TITLE
fix: double request issue when group keyword changes

### DIFF
--- a/src/atom/searchInfoStore.ts
+++ b/src/atom/searchInfoStore.ts
@@ -1,5 +1,5 @@
-import { INIT_INTEREST_KEYWORD, INTEREST_KEYWORD } from "@/utils/constant";
-import { atom } from "recoil";
+import { INIT_INTEREST_KEYWORD, INTEREST_KEYWORD } from '@/utils/constant';
+import { atom } from 'recoil';
 
 export type SearchInfoType = {
     searchText: string;
@@ -13,13 +13,15 @@ export type SearchInfoType = {
     page: number;
 };
 
+export const INIT_SEARCH_INFO = {
+    searchText: '',
+    division: [] as string[],
+    filterKeyword: INIT_INTEREST_KEYWORD,
+    prevFilterKeyword: INIT_INTEREST_KEYWORD,
+    page: 0,
+};
+
 export const searchInfoState = atom({
     key: 'searchInfoState',
-    default: {
-        searchText: '',
-        division: [] as string[],
-        filterKeyword: INIT_INTEREST_KEYWORD,
-        prevFilterKeyword: INIT_INTEREST_KEYWORD,
-        page: 0,
-    }
-})
+    default: INIT_SEARCH_INFO,
+});

--- a/src/pages/totalBabpool/TotalBabpoolPage.tsx
+++ b/src/pages/totalBabpool/TotalBabpoolPage.tsx
@@ -1,6 +1,6 @@
 import { getProfiles, getisRegistrationProfile } from '@/api/profile/profileApi';
 import { colors } from '@/assets/styles/theme';
-import { SearchInfoType, searchInfoState } from '@/atom/searchInfoStore';
+import { INIT_SEARCH_INFO, SearchInfoType, searchInfoState } from '@/atom/searchInfoStore';
 import Header from '@/components/common/header';
 import Overlay from '@/components/common/overlay';
 import ProfileBox from '@/components/profile/ProfileBox';
@@ -69,8 +69,9 @@ export default function TotalBabpoolPage() {
     };
 
     const { data, isError, isLoading } = useQuery<ProfilesType>({
-        queryKey: ['profiles', groupName],
-        queryFn: fetchProfileList,
+        queryKey: ['profiles', searchInfo],
+        queryFn: fetchProfileList, 
+        staleTime: 1000 * 60 * 5,
     });
     const { navigate, authCheck } = useNavigation();
 
@@ -143,6 +144,10 @@ export default function TotalBabpoolPage() {
                       }
                     : INIT_INTEREST_KEYWORD,
         }));
+
+        return () => {
+            setSearchInfo(INIT_SEARCH_INFO);
+        }
     }, [groupName]);
 
     useEffect(() => {


### PR DESCRIPTION
Resolves 109
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- query 키를 group으로 지정하였더니 필터값 변경이나 페이지가 변경되면 refetch가 이루어지지 않음
- key값은 searchInfo 그대로 유지하고 slateTime을 5분으로 지정하여 중복요청의 경우 네트워크 재요청 보내지 않도록 변경

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->